### PR TITLE
Fix crawler metadata routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
-		"lint": "prettier --check . && eslint ."
+		"lint": "prettier --check . && eslint .",
+		"test": "node --test tests/*.test.mjs"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.4.1",

--- a/src/routes/.well-known/security.txt/+server.ts
+++ b/src/routes/.well-known/security.txt/+server.ts
@@ -2,12 +2,14 @@ import { absoluteUrl } from '$lib/site';
 
 export const prerender = false;
 
+const expires = '2027-07-25T23:59:59.000Z';
+
 export function GET() {
 	return new Response(
-		`User-agent: *
-Allow: /
-
-Sitemap: ${absoluteUrl('/sitemap.xml')}
+		`Contact: ${absoluteUrl('/contact')}
+Expires: ${expires}
+Preferred-Languages: en
+Canonical: ${absoluteUrl('/.well-known/security.txt')}
 `,
 		{
 			headers: {

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,36 +1,16 @@
-import { locations } from '$lib/locations';
-import { posts } from '$lib/posts';
-import { services } from '$lib/services';
-import { site } from '$lib/site';
+import { absoluteUrl } from '$lib/site';
 
-export const prerender = true;
+export const prerender = false;
 
-const staticPaths = [
-	'/',
-	'/about/',
-	'/services/',
-	'/locations/',
-	'/resources/',
-	'/contact/',
-	'/routing/'
-];
+const sitemapPaths = ['/', '/services', '/about'];
 
 export function GET() {
-	const paths = [
-		...staticPaths,
-		...services.map((service) => `/services/${service.slug}/`),
-		...locations.map((location) => `/locations/${location.slug}/`),
-		...posts.map((post) => `/resources/${post.slug}/`)
-	];
-
 	const body = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${paths
+${sitemapPaths
 	.map(
 		(path) => `	<url>
-		<loc>${site.url}${path}</loc>
-		<changefreq>${path === '/' ? 'weekly' : 'monthly'}</changefreq>
-		<priority>${path === '/' ? '1.0' : '0.7'}</priority>
+		<loc>${absoluteUrl(path)}</loc>
 	</url>`
 	)
 	.join('\n')}

--- a/tests/metadata-routes.test.mjs
+++ b/tests/metadata-routes.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { after, before, describe, it } from 'node:test';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const expectedSiteUrl = 'https://h2technologiesllc.com';
+
+let server;
+let baseUrl;
+
+async function findOpenPort() {
+	return await new Promise((resolve, reject) => {
+		const listener = createServer();
+		listener.once('error', reject);
+		listener.listen(0, '127.0.0.1', () => {
+			const address = listener.address();
+			listener.close(() => {
+				resolve(address.port);
+			});
+		});
+	});
+}
+
+async function waitForServer(url) {
+	const deadline = Date.now() + 10_000;
+	let lastError;
+
+	while (Date.now() < deadline) {
+		try {
+			const response = await fetch(url);
+			if (response.ok) {
+				return;
+			}
+		} catch (error) {
+			lastError = error;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 150));
+	}
+
+	throw lastError ?? new Error(`Server did not become ready at ${url}`);
+}
+
+async function fetchRoute(path) {
+	const response = await fetch(`${baseUrl}${path}`, { redirect: 'manual' });
+	const body = await response.text();
+
+	assert.equal(response.status, 200, `${path} should return HTTP 200`);
+	assert.doesNotMatch(body, /<html|<script/i, `${path} should not return the app shell`);
+
+	return {
+		body,
+		contentType: response.headers.get('content-type') ?? ''
+	};
+}
+
+before(async () => {
+	assert.ok(
+		existsSync(new URL('../build/index.js', import.meta.url)),
+		'Run `pnpm run build` first'
+	);
+
+	const port = await findOpenPort();
+	baseUrl = `http://127.0.0.1:${port}`;
+	server = spawn(process.execPath, ['build/index.js'], {
+		cwd: root,
+		env: {
+			...process.env,
+			HOST: '127.0.0.1',
+			PORT: String(port),
+			NODE_ENV: 'production'
+		},
+		stdio: ['ignore', 'pipe', 'pipe']
+	});
+
+	await waitForServer(baseUrl);
+});
+
+after(() => {
+	server?.kill();
+});
+
+describe('production metadata routes', () => {
+	it('serves robots.txt directly with the canonical sitemap', async () => {
+		const { body, contentType } = await fetchRoute('/robots.txt');
+
+		assert.match(contentType, /^text\/plain\b/i);
+		assert.equal(
+			body,
+			`User-agent: *
+Allow: /
+
+Sitemap: ${expectedSiteUrl}/sitemap.xml
+`
+		);
+	});
+
+	it('serves sitemap.xml directly with the canonical public URLs', async () => {
+		const { body, contentType } = await fetchRoute('/sitemap.xml');
+		const locs = [...body.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+
+		assert.match(contentType, /^application\/xml\b/i);
+		assert.match(body, /^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+		assert.match(body, /<urlset xmlns="http:\/\/www\.sitemaps\.org\/schemas\/sitemap\/0\.9">/);
+		assert.deepEqual(locs, [
+			`${expectedSiteUrl}/`,
+			`${expectedSiteUrl}/services`,
+			`${expectedSiteUrl}/about`
+		]);
+		assert.match(body.trimEnd(), /<\/urlset>$/);
+	});
+
+	it('serves RFC 9116 security.txt directly', async () => {
+		const { body, contentType } = await fetchRoute('/.well-known/security.txt');
+		const expires = body.match(/^Expires: (.+)$/m)?.[1];
+
+		assert.match(contentType, /^text\/plain\b/i);
+		assert.equal(
+			body,
+			`Contact: ${expectedSiteUrl}/contact
+Expires: 2027-07-25T23:59:59.000Z
+Preferred-Languages: en
+Canonical: ${expectedSiteUrl}/.well-known/security.txt
+`
+		);
+		assert.ok(expires, 'security.txt should include Expires');
+		assert.ok(Date.parse(expires) > Date.now(), 'security.txt Expires should be in the future');
+	});
+});


### PR DESCRIPTION
## Summary

Updates the H2 Technologies crawler and security-disclosure metadata routes so production requests receive direct endpoint responses instead of SPA fallback content.

## Changes

- Serves `/robots.txt` as plain text with normal crawling allowed and the canonical sitemap URL.
- Serves `/sitemap.xml` as XML containing the canonical URLs for `/`, `/services`, and `/about`.
- Adds `/.well-known/security.txt` with RFC 9116 fields: `Contact`, `Expires`, `Preferred-Languages`, and `Canonical`.
- Adds Node test coverage that starts the built adapter-node server and verifies all three routes return HTTP 200, non-HTML bodies, and expected content types/content.

## Validation

- `pnpm run check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm test`

Note: the production build still emits the existing `vite-plugin-svelte` warning about `svelte-use-form` missing an exports condition for its `svelte` field; the build completed successfully.